### PR TITLE
Assorted Debian improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 !/debian/copyright
 !/debian/dh-package-notes.install
 !/debian/dh-package-notes.manpages
+!/debian/generate-package-notes.1
 !/debian/rules
 !/debian/source/format

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 /*.src.rpm
-/*/
+/*/**
 /*.log
+!/debian/changelog
+!/debian/control
+!/debian/copyright
+!/debian/dh-package-notes.install
+!/debian/dh-package-notes.manpages
+!/debian/rules
+!/debian/source/format

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+package-notes (0.2) unstable; urgency=medium
+
+  [ Mark Wielaard ]
+  * generate-package-notes.py: Add --debuginfod argument
+
+  [ Victor Westerhuis ]
+  * Add Debian debuginfod server in dh_package_notes
+  * Provide dh-sequence-package_notes
+  * Fix Python installation
+  * Add manpage for generate-package-notes
+
+ -- Luca Boccassi <bluca@debian.org>  Sat, 15 May 2021 01:09:57 +0200
+
 package-notes (0.1) unstable; urgency=medium
 
   * Initial packaging

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: admin
 Priority: optional
 Rules-Requires-Root: no
 Maintainer: Luca Boccassi <bluca@debian.org>
-Build-Depends: debhelper-compat (= 12)
+Build-Depends: debhelper-compat (= 12), dh-sequence-python3, dh-exec
 Standards-Version: 4.5.1
 Homepage: https://systemd.io/COREDUMP_PACKAGE_METADATA/
 Vcs-Git: https://github.com/systemd/package-notes.git
@@ -12,7 +12,7 @@ Vcs-Browser: https://github.com/systemd/package-notes
 Package: dh-package-notes
 Architecture: all
 Enhances: debhelper
-Depends: ${misc:Depends}, ${perl:Depends}, debhelper, python3:any
+Depends: ${misc:Depends}, ${perl:Depends}, debhelper, ${python3:Depends}
 Provides: dh-sequence-package-notes
 Description: Debian Helper for adding package metadata to ELF binaries
  Generate a linker script to add package metadata to the ELF binaries being

--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,7 @@ Package: dh-package-notes
 Architecture: all
 Enhances: debhelper
 Depends: ${misc:Depends}, ${perl:Depends}, debhelper, python3:any
+Provides: dh-sequence-package-notes
 Description: Debian Helper for adding package metadata to ELF binaries
  Generate a linker script to add package metadata to the ELF binaries being
  built. See: https://systemd.io/COREDUMP_PACKAGE_METADATA/

--- a/debian/dh-package-notes.install
+++ b/debian/dh-package-notes.install
@@ -1,3 +1,4 @@
+#!/usr/bin/dh-exec
 dh_package_notes usr/bin
-generate-package-notes.py usr/share/debhelper
+generate-package-notes.py => usr/bin/generate-package-notes
 package_notes.pm usr/share/perl5/Debian/Debhelper/Sequence

--- a/debian/dh-package-notes.manpages
+++ b/debian/dh-package-notes.manpages
@@ -1,1 +1,2 @@
 debian/dh_package_notes.1
+debian/generate-package-notes.1

--- a/debian/generate-package-notes.1
+++ b/debian/generate-package-notes.1
@@ -1,0 +1,128 @@
+.TH GENERATE\-PACKAGE\-NOTES 1 "May 2021"
+.SH NAME
+generate\-package\-notes \- generate a linker script for package metadata
+.SH SYNOPSIS
+.B generate\-package\-notes
+.RI [ OPTION ...]
+.SH DESCRIPTION
+ELF binaries get stamped with a unique, build-time generated hex string
+identifier called build-id, which gets embedded as an ELF note called
+.IR \%.note.gnu.build\-id .
+In most cases, this allows to associate a stripped binary with
+its debugging information.
+It is used, for example, to dynamically fetch DWARF symbols from
+a debuginfo server, or to query the local package manager and find out
+the package metadata or, again, the DWARF symbols or program sources.
+.PP
+However, this usage of the build-id requires either local metadata,
+usually set up by the package manager,
+or access to a remote server over the network.
+Both of those might be unavailable or forbidden.
+.PP
+Thus it becomes desirable to add additional metadata to a binary
+at build time, so that
+.BR \%systemd\-coredump (8)
+and other services analyzing
+core files are able to extract said metadata simply from the core file
+itself, without external dependencies.
+The metadata is embedded in a single ELF header section,
+in a key-value JSON format.
+.PP
+The metadata format is intentionally left open,
+so that vendors can add their own information.
+A set of well-known keys is defined in the document
+.UR https://systemd.io/COREDUMP_PACKAGE_METADATA/
+.B Package Metadata for Core Files
+.UE ,
+and hopefully shared among all vendors.
+.PP
+.B generate\-package\-notes
+generates a linker script on standard output,
+which can then be used at build time via
+.I \%LDFLAGS="\-Wl,\-T,/path/to/generated/script"
+to include the note in the binary.
+If a Debian package is built using the
+.BR dh (1)
+sequencer, the generation can be partly automated using
+.BR \%dh_package_notes (1).
+.SH OPTIONS
+.TP
+.BI \-\-package\-type= TYPE
+Set the key
+.I type
+to
+.IR TYPE .
+This defaults to
+.IR package ,
+but for Debian packages it should be set to
+.IR deb .
+.TP
+.BI \-\-package\-name= NAME
+Set the key
+.I name
+to
+.IR NAME .
+This defaults to the empty string, but for Debian packages it should
+be set to the name of the binary package containing the binary.
+.TP
+.BI \-\-package\-version= VERSION
+Set the key
+.I version
+to
+.IR VERSION .
+This defaults to the empty string, but for Debian packages it should
+be set to the Debian version of the binary package containing the binary.
+.TP
+.BI \-\-cpe= CPE
+Set the key
+.I osCpe
+to
+.IR CPE .
+This defaults to the value of the
+.I CPE_NAME
+field in the first of
+.I /etc/os\-release
+or
+.I /usr/lib/os\-release
+that exists.
+Otherwise the key
+.I osCpe
+is omitted in the note.
+.TP
+.BI \-\-rpm= PACKAGE \- VERSION
+Set the keys
+.I type
+to
+.BR rpm ,
+.I name
+to
+.IR PACKAGE ,
+and
+.I version
+to
+.IR VERSION .
+Overrides
+.BR \-\-package\-type ,
+.BR \-\-package\-name ,
+and
+.BR \-\-package\-version .
+.TP
+.BI \-\-debug\-info\-url= URL
+Set the key
+.I debugInfoUrl
+to
+.IR URL .
+By default this key is omitted, but for Debian packages it should
+be set to the official Debian debuginfod server address
+.IR https://debuginfod.debian.org/ .
+.TP
+.BR \-h ", " \-\-help
+Show a short help message and exit.
+.SH SEE ALSO
+.ad l
+.nh
+.BR dh_package_notes (1),
+.BR systemd\-coredump (8),
+.UR https://systemd.io/COREDUMP_PACKAGE_METADATA/
+.B Package Metadata for Core Files
+.UE

--- a/debian/rules
+++ b/debian/rules
@@ -6,5 +6,8 @@
 execute_after_dh_auto_build:
 	pod2man dh_package_notes $(CURDIR)/debian/dh_package_notes.1
 
+override_dh_python3:
+	dh_python3 --depends simplejson
+
 execute_after_dh_auto_clean:
 	rm -f $(CURDIR)/debian/dh_package_notes.1

--- a/dh_package_notes
+++ b/dh_package_notes
@@ -47,7 +47,7 @@ isnative( $dh{MAINPACKAGE} );    # Necessary to have $dh{VERSION}
 my $source_package = sourcepackage();
 my %options        = ( 'stdout' => "debian/.debhelper/notes.ld" );
 my @cmd            = (
-    "python3",           "/usr/share/debhelper/generate-package-notes.py",
+    "/usr/bin/generate-package-notes",
     "--package-type",    "deb",
     "--package-name",    ${source_package},
     "--package-version", $dh{VERSION},

--- a/dh_package_notes
+++ b/dh_package_notes
@@ -32,6 +32,7 @@ B<debian/.debhelper/notes.ld> with the package type set to B<deb>, the package
 name and version set to the source package name and version respectively, and
 the B<os> and B<osVersion> fields set to the values of the B<ID> and
 B<VERSION_ID> fields found in B</etc/os-release>. Simply add
+B<dh-sequence-package-notes> to the Build-Depends or add
 B<--with package_notes> to the B<dh $@> call to make this happen.
 
 The package using B<dh_package_notes> also needs to manually set in debian/rules

--- a/dh_package_notes
+++ b/dh_package_notes
@@ -49,7 +49,8 @@ my @cmd            = (
     "python3",           "/usr/share/debhelper/generate-package-notes.py",
     "--package-type",    "deb",
     "--package-name",    ${source_package},
-    "--package-version", $dh{VERSION}
+    "--package-version", $dh{VERSION},
+    "--debug-info-url",  "https://debuginfod.debian.net"
 );
 
 if ( not mkdir("debian/.debhelper") ) {


### PR DESCRIPTION
Since `generate-package-notes.py` understands `--debuginfod` now,
let's pass the Debian debuginfod server in `dh_package_notes`.