### PR TITLE
ci: lint the codebase

### DIFF
--- a/.github/super-linter-links/dh/dh_package_notes.pl
+++ b/.github/super-linter-links/dh/dh_package_notes.pl
@@ -1,0 +1,1 @@
+../../../dh/dh_package_notes

--- a/.github/super-linter-links/generate-package-notes.py
+++ b/.github/super-linter-links/generate-package-notes.py
@@ -1,0 +1,1 @@
+../../generate-package-notes

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,44 @@
+---
+# SPDX-License-Identifier: CC0-1.0
+# vi: ts=2 sw=2 et:
+
+name: Lint Code Base
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Repository checkout
+        uses: actions/checkout@v2
+        with:
+          # We need a full repo clone to get a correct list of changed files
+          fetch-depth: 0
+        # FIXME: super-linter doesn't recognize perl/python scripts without
+        #        an extension; let's workaround it by creating a dummy symlink
+        #        directory with necessary extensions until it's resolved.
+        #        The `find` below just checks if all symlinks in the dummy
+        #        directory are valid.
+      - name: Check test-related symlinks
+        run: find .github/super-linter-links/ -type l -exec ls -L {} +
+      - name: Lint Code Base
+        uses: github/super-linter/slim@latest
+        env:
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MULTI_STATUS: true
+          # FIXME: until the above FIXME is resolved, we need to always check
+          #        the whole codebase, otherwise only changed files would be
+          #        considered, which would ignore the symlinked files. Since
+          #        we have only couple of files to check, it's not an issue
+          #        (yet).
+          VALIDATE_ALL_CODEBASE: true
+          VALIDATE_BASH: true
+          VALIDATE_PERL: true
+          VALIDATE_PYTHON_ISORT: true
+          VALIDATE_PYTHON_PYLINT: true

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -6,6 +6,7 @@ from importlib import resources
 
 from _generate_package_notes import generate_section
 
+
 class TestGeneratedOutput(unittest.TestCase):
     def test_fedora_package(self):
         input = dict(type='rpm', name='package', version='1.2.3', architecture='noarch', osCpe='CPE')

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: CC0-1.0
 
+import sys
 import unittest
 from importlib import resources
 


### PR DESCRIPTION
This PR introduces, so far, linting for shell scripts (shellcheck), perl (Perl::Critic), and python (pylint, isort). I'm not sure if we want to enable `black` and/or `flake8` as well, since that'd require some tinkering (either in reformating the python code or writing custom configs), so please let me know.

Also, it wouldn't be a CI without issues, so there's a bug in super-linter, which causes perl and python scripts without an extension to get ignored. I'll bring this up in the super-linter repo, but until it's fixed I created a "dummy" directory (`.github/super-linter-links`) with "extension-ified" symlinks to the respective files without an extension, which works around this issue.

PTAL.