### PR TITLE
tests: move back to pytest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Repository checkout
         uses: actions/checkout@v2
       - name: Install dependencies
-        run: sudo apt -y install binutils python3-simplejson
+        run: sudo apt -y install binutils python3-pytest python3-simplejson
       - name: Run tests
-        run: cd tests && python3 -m unittest -v
+        run: python3 -m pytest -v
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,41 +1,36 @@
 # SPDX-License-Identifier: CC0-1.0
 
 import sys
-import unittest
 from importlib import resources
 
 from _generate_package_notes import generate_section
 
 
-class TestGeneratedOutput(unittest.TestCase):
-    def test_fedora_package(self):
-        input = dict(type='rpm', name='package', version='1.2.3', architecture='noarch', osCpe='CPE')
-        text = '\n'.join(generate_section(input))
-        expected = resources.read_text('resources', 'fedora-package.ld')
-        self.assertEqual(text, expected[:-1])
+def test_fedora_package():
+    input = dict(type='rpm', name='package', version='1.2.3', architecture='noarch', osCpe='CPE')
+    text = '\n'.join(generate_section(input))
+    expected = resources.read_text('resources', 'fedora-package.ld')
+    assert text == expected[:-1]
 
-    def test_very_short(self):
-        input = dict(type='deb', name='A', version='0', architecture='x', osCpe='o')
-        text = '\n'.join(generate_section(input))
-        expected = resources.read_text('resources', 'very-short.ld')
-        self.assertEqual(text, expected[:-1])
+def test_very_short():
+    input = dict(type='deb', name='A', version='0', architecture='x', osCpe='o')
+    text = '\n'.join(generate_section(input))
+    expected = resources.read_text('resources', 'very-short.ld')
+    assert text == expected[:-1]
 
-    def test_very_short_rw(self):
-        input = dict(type='deb', name='A', version='0', architecture='x', osCpe='o')
-        text = '\n'.join(generate_section(input, readonly=False))
-        expected = resources.read_text('resources', 'very-short-rw.ld')
-        self.assertEqual(text, expected[:-1])
+def test_very_short_rw():
+    input = dict(type='deb', name='A', version='0', architecture='x', osCpe='o')
+    text = '\n'.join(generate_section(input, readonly=False))
+    expected = resources.read_text('resources', 'very-short-rw.ld')
+    assert text == expected[:-1]
 
-    def test_fedora_long_name(self):
-        input = dict(type='rpm',
-                     name='rust-plist+enable_unstable_features_that_may_break_with_minor_version_bumps-devel',
-                     version='200:1.3.1~rc1.post2^final3',
-                     architecture='ppc64le',
-                     osCpe='cpe:/o:fedoraproject:fedora:35',
-                     debugInfoUrl='https://somewhere.on.the.internet.there.is.a.server.which.is.never.wrong/query')
-        text = '\n'.join(generate_section(input))
-        expected = resources.read_text('resources', 'fedora-long-name.ld')
-        self.assertEqual(text, expected[:-1])
-
-if __name__ == '__main__':
-    unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout, verbosity=3))
+def test_fedora_long_name():
+    input = dict(type='rpm',
+                 name='rust-plist+enable_unstable_features_that_may_break_with_minor_version_bumps-devel',
+                 version='200:1.3.1~rc1.post2^final3',
+                 architecture='ppc64le',
+                 osCpe='cpe:/o:fedoraproject:fedora:35',
+                 debugInfoUrl='https://somewhere.on.the.internet.there.is.a.server.which.is.never.wrong/query')
+    text = '\n'.join(generate_section(input))
+    expected = resources.read_text('resources', 'fedora-long-name.ld')
+    assert text == expected[:-1]


### PR DESCRIPTION
Oh well, in 8dae5747ba9b64b8c78794cffa52221b48ef428d I completely missed the fact the tests are already working via `pytest`, since I've never used it before, and blindly converted them to `unittest` instead. This realization came to me thanks to https://github.com/systemd/mkosi/pull/882#issuecomment-1016595462 and I agree with @keszybz that the code is much more readable with `pytest` (and drops a lot of boilerplate). So let's revert the change back.