### PR TITLE
use LONG instead of BYTEs for binary fields

### DIFF
--- a/generate-package-notes.py
+++ b/generate-package-notes.py
@@ -138,14 +138,10 @@ def encode_bytes_lines(arr, prefix='', label='string'):
 
 def encode_length(s, prefix='', label='string'):
     n = (len(s) + 1) * 4 // 4
-    n1 = n % 0x100
-    n2 = n // 0x100
-    assert n2 < 0x100
-    return prefix + encode_bytes([n1, n2, 0, 0]) + ' /* Length of {} including NUL */'.format(label)
+    return f'{prefix}LONG(0x{n:04x})                                /* Length of {label} including NUL */'
 
-def encode_note_id(arr, prefix=''):
-    assert len(arr) == 4
-    return prefix + encode_bytes(arr) + ' /* Note ID */'
+def encode_note_id(id, prefix=''):
+    return f'{prefix}LONG(0x{id:04x})                            /* Note ID */'
 
 def pad_string(s):
     return [0] * ((len(s) + 4) // 4 * 4 - len(s))
@@ -166,7 +162,7 @@ def encode_note(note_name, note_id, owner, value, readonly=True, prefix=''):
             l1, l2, l3, *l4, *l5,
             prefix + '}']
 
-NOTE_ID = [0x7E, 0x1A, 0xFE, 0xCA]
+NOTE_ID= 0xcafe1a7e
 
 def json_serialize(s):
     # Avoid taking space in the ELF header if there's no value to store

--- a/generate-package-notes.sh
+++ b/generate-package-notes.sh
@@ -253,11 +253,13 @@ write_script() {
 
     printf 'SECTIONS\n{\n'
     printf '    .note.package %s: ALIGN(4) {\n' "${readonly}"
-    printf '        BYTE(0x04) BYTE(0x00) BYTE(0x00) BYTE(0x00) /* Length of Owner including NUL */\n'
-    printf '        BYTE(0x%02x) BYTE(0x%02x) BYTE(0x00) BYTE(0x00) /* Length of Value including NUL */\n' \
-           $((value_len % 256)) $((value_len / 256))
+    # Note that for the binary fields we use the native 4 bytes type, to avoid
+    # endianness issues.
+    printf '        LONG(0x0004)                                /* Length of Owner including NUL */\n'
+    printf '        LONG(0x%04x)                                /* Length of Value including NUL */\n' \
+        ${value_len}
+    printf '        LONG(0xcafe1a7e)                            /* Note ID */\n'
 
-    printf '        BYTE(0x7e) BYTE(0x1a) BYTE(0xfe) BYTE(0xca) /* Note ID */\n'
     printf "        BYTE(0x46) BYTE(0x44) BYTE(0x4f) BYTE(0x00) /* Owner: 'FDO\\\\x00' */" # newline will be added by write_string
 
     write_string "$1" '        ' 'Value' "$value_len"

--- a/tests/resources/fedora-cpe-os-release.ld
+++ b/tests/resources/fedora-cpe-os-release.ld
@@ -1,9 +1,9 @@
 SECTIONS
 {
     .note.package (READONLY) : ALIGN(4) {
-        BYTE(0x04) BYTE(0x00) BYTE(0x00) BYTE(0x00) /* Length of Owner including NUL */
-        BYTE(0x38) BYTE(0x00) BYTE(0x00) BYTE(0x00) /* Length of Value including NUL */
-        BYTE(0x7e) BYTE(0x1a) BYTE(0xfe) BYTE(0xca) /* Note ID */
+        LONG(0x0004)                                /* Length of Owner including NUL */
+        LONG(0x0038)                                /* Length of Value including NUL */
+        LONG(0xcafe1a7e)                            /* Note ID */
         BYTE(0x46) BYTE(0x44) BYTE(0x4f) BYTE(0x00) /* Owner: 'FDO\x00' */
         BYTE(0x7b) BYTE(0x22) BYTE(0x74) BYTE(0x79) /* Value: '{"type":"rpm","osCpe":"cpe:/o:fedoraproject:fedora:34"}\x00' */
         BYTE(0x70) BYTE(0x65) BYTE(0x22) BYTE(0x3a)

--- a/tests/resources/fedora-cpe-system-release.ld
+++ b/tests/resources/fedora-cpe-system-release.ld
@@ -1,9 +1,9 @@
 SECTIONS
 {
     .note.package (READONLY) : ALIGN(4) {
-        BYTE(0x04) BYTE(0x00) BYTE(0x00) BYTE(0x00) /* Length of Owner including NUL */
-        BYTE(0x38) BYTE(0x00) BYTE(0x00) BYTE(0x00) /* Length of Value including NUL */
-        BYTE(0x7e) BYTE(0x1a) BYTE(0xfe) BYTE(0xca) /* Note ID */
+        LONG(0x0004)                                /* Length of Owner including NUL */
+        LONG(0x0038)                                /* Length of Value including NUL */
+        LONG(0xcafe1a7e)                            /* Note ID */
         BYTE(0x46) BYTE(0x44) BYTE(0x4f) BYTE(0x00) /* Owner: 'FDO\x00' */
         BYTE(0x7b) BYTE(0x22) BYTE(0x74) BYTE(0x79) /* Value: '{"type":"rpm","osCpe":"cpe:/o:fedoraproject:fedora:33"}\x00' */
         BYTE(0x70) BYTE(0x65) BYTE(0x22) BYTE(0x3a)

--- a/tests/resources/fedora-long-name.ld
+++ b/tests/resources/fedora-long-name.ld
@@ -1,9 +1,9 @@
 SECTIONS
 {
     .note.package (READONLY) : ALIGN(4) {
-        BYTE(0x04) BYTE(0x00) BYTE(0x00) BYTE(0x00) /* Length of Owner including NUL */
-        BYTE(0x33) BYTE(0x01) BYTE(0x00) BYTE(0x00) /* Length of Value including NUL */
-        BYTE(0x7e) BYTE(0x1a) BYTE(0xfe) BYTE(0xca) /* Note ID */
+        LONG(0x0004)                                /* Length of Owner including NUL */
+        LONG(0x0133)                                /* Length of Value including NUL */
+        LONG(0xcafe1a7e)                            /* Note ID */
         BYTE(0x46) BYTE(0x44) BYTE(0x4f) BYTE(0x00) /* Owner: 'FDO\x00' */
         BYTE(0x7b) BYTE(0x22) BYTE(0x74) BYTE(0x79) /* Value: '{"type":"rpm","name":"rust-plist+enable_unstable_features_that_may_break_with_minor_version_bumps-devel","version":"200:1.3.1~rc1.post2^final3","architecture":"ppc64le","osCpe":"cpe:/o:fedoraproject:fedora:35","debugInfoUrl":"https://somewhere.on.the.internet.there.is.a.server.which.is.never.wrong/query"}\x00\x00' */
         BYTE(0x70) BYTE(0x65) BYTE(0x22) BYTE(0x3a)

--- a/tests/resources/fedora-package.ld
+++ b/tests/resources/fedora-package.ld
@@ -1,9 +1,9 @@
 SECTIONS
 {
     .note.package (READONLY) : ALIGN(4) {
-        BYTE(0x04) BYTE(0x00) BYTE(0x00) BYTE(0x00) /* Length of Owner including NUL */
-        BYTE(0x58) BYTE(0x00) BYTE(0x00) BYTE(0x00) /* Length of Value including NUL */
-        BYTE(0x7e) BYTE(0x1a) BYTE(0xfe) BYTE(0xca) /* Note ID */
+        LONG(0x0004)                                /* Length of Owner including NUL */
+        LONG(0x0058)                                /* Length of Value including NUL */
+        LONG(0xcafe1a7e)                            /* Note ID */
         BYTE(0x46) BYTE(0x44) BYTE(0x4f) BYTE(0x00) /* Owner: 'FDO\x00' */
         BYTE(0x7b) BYTE(0x22) BYTE(0x74) BYTE(0x79) /* Value: '{"type":"rpm","name":"package","version":"1.2.3","architecture":"noarch","osCpe":"CPE"}\x00' */
         BYTE(0x70) BYTE(0x65) BYTE(0x22) BYTE(0x3a)

--- a/tests/resources/very-short-rw.ld
+++ b/tests/resources/very-short-rw.ld
@@ -1,9 +1,9 @@
 SECTIONS
 {
     .note.package : ALIGN(4) {
-        BYTE(0x04) BYTE(0x00) BYTE(0x00) BYTE(0x00) /* Length of Owner including NUL */
-        BYTE(0x47) BYTE(0x00) BYTE(0x00) BYTE(0x00) /* Length of Value including NUL */
-        BYTE(0x7e) BYTE(0x1a) BYTE(0xfe) BYTE(0xca) /* Note ID */
+        LONG(0x0004)                                /* Length of Owner including NUL */
+        LONG(0x0047)                                /* Length of Value including NUL */
+        LONG(0xcafe1a7e)                            /* Note ID */
         BYTE(0x46) BYTE(0x44) BYTE(0x4f) BYTE(0x00) /* Owner: 'FDO\x00' */
         BYTE(0x7b) BYTE(0x22) BYTE(0x74) BYTE(0x79) /* Value: '{"type":"deb","name":"A","version":"0","architecture":"x","osCpe":"o"}\x00\x00' */
         BYTE(0x70) BYTE(0x65) BYTE(0x22) BYTE(0x3a)

--- a/tests/resources/very-short.ld
+++ b/tests/resources/very-short.ld
@@ -1,9 +1,9 @@
 SECTIONS
 {
     .note.package (READONLY) : ALIGN(4) {
-        BYTE(0x04) BYTE(0x00) BYTE(0x00) BYTE(0x00) /* Length of Owner including NUL */
-        BYTE(0x47) BYTE(0x00) BYTE(0x00) BYTE(0x00) /* Length of Value including NUL */
-        BYTE(0x7e) BYTE(0x1a) BYTE(0xfe) BYTE(0xca) /* Note ID */
+        LONG(0x0004)                                /* Length of Owner including NUL */
+        LONG(0x0047)                                /* Length of Value including NUL */
+        LONG(0xcafe1a7e)                            /* Note ID */
         BYTE(0x46) BYTE(0x44) BYTE(0x4f) BYTE(0x00) /* Owner: 'FDO\x00' */
         BYTE(0x7b) BYTE(0x22) BYTE(0x74) BYTE(0x79) /* Value: '{"type":"deb","name":"A","version":"0","architecture":"x","osCpe":"o"}\x00\x00' */
         BYTE(0x70) BYTE(0x65) BYTE(0x22) BYTE(0x3a)


### PR DESCRIPTION
We hard-code little-endian byte sequences for binary fields, but
that clearly doesn't work on big endian architectures like s390x.
Switch to single LONG per 4-bytes field, so that the right thing
happens automatically.

Displaying notes found in: .note.package
  Owner                Data size        Description
readelf: /usr/bin/bash: Warning: note with invalid namesz and/or descsz
found at offset 0x0
readelf: /usr/bin/bash: Warning:  type: 0x7e1afeca, namesize:
0x04000000, descsize: 0x78000000, alignment: 4