### PR TITLE
Check manpage in git

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all:
 
 dlopen-notes.1: dlopen-notes.py docs/dlopen-description.man Makefile
 	argparse-manpage 	\
-		--output=$@ 	\
+		--output=docs/$@ 	\
 		--pyfile=$< 	\
 		--function=make_parser \
 		--project-name=package-notes \

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ dlopen-notes.1: dlopen-notes.py docs/dlopen-description.man Makefile
 
 install:
 	install -m 755 -D dlopen-notes.py $(DESTDIR)/usr/bin/dlopen-notes
+	install -m 644 -D docs/dlopen-notes.1 $(DESTDIR)/usr/share/man/man1/dlopen-notes.1
 
 check:
 	make -C test check

--- a/debian/dh-dlopenlibdeps.manpages
+++ b/debian/dh-dlopenlibdeps.manpages
@@ -1,1 +1,2 @@
 debian/dh_dlopenlibdeps.1
+usr/share/man/man1/dlopen-notes.1

--- a/docs/dlopen-notes.1
+++ b/docs/dlopen-notes.1
@@ -1,0 +1,38 @@
+.TH DLOPEN\-NOTES.PY "1" "2024\-05\-22" "package\-notes" "Generated Python Manual"
+.SH NAME
+dlopen\-notes.py
+.SH SYNOPSIS
+.B dlopen\-notes.py
+[-r] [-s] [-f [FEATURE1,FEATURE2]] [-h] filename [filename ...]
+.SH DESCRIPTION
+Read .note.dlopen notes from ELF files and report the contents.
+.PP
+ELF binaries store link-time dependencies in their headers, which can be parsed
+by various tools. There is no machine-readable metadata about dependencies
+loaded at build time via
+.BR \%dlopen (3)
+available by default. The ELF Dlopen Metadata specification aims to fill this
+gap, by defining a common format.
+.PP
+This tool allows parsing such a note, and printing out the result in various
+formats.
+
+.TP
+\fBfilename\fR
+Library file to extract notes from
+
+.SH OPTIONS
+.TP
+\fB\-r\fR, \fB\-\-raw\fR
+Show the original JSON extracted from input files
+
+.TP
+\fB\-s\fR, \fB\-\-sonames\fR
+List all sonames and their priorities, one soname per line
+
+.TP
+\fB\-f\fR \fI\,[FEATURE1,FEATURE2]\/\fR, \fB\-\-features\fR \fI\,[FEATURE1,FEATURE2]\/\fR
+Describe features, can be specified multiple times
+
+.SH COMMENTS
+If no option is specifed, \-\-raw is the default.


### PR DESCRIPTION
Generating it requires a very new argparse-manpage, which is not
available in Debian stable. It's not going to change often, and
there's a makefile rule to regenerate it, so just check it in.