### PR TITLE
dh_dlopenlibdeps: Debian package names can contain dots

### DIFF
--- a/debian/dh_dlopenlibdeps
+++ b/debian/dh_dlopenlibdeps
@@ -102,7 +102,7 @@ on_pkgs_in_parallel {
 					if ($line =~ m/^local diversion |^diversion by/) {
 						next;
 					}
-					if ($line =~ m/^([-a-z0-9+]+):/) {
+					if ($line =~ m/^([-a-z0-9+.]+):/) {
 						$required_packages{$1} = 1;
 					}
 				}
@@ -115,7 +115,7 @@ on_pkgs_in_parallel {
 					if ($line =~ m/^local diversion |^diversion by/) {
 						next;
 					}
-					if ($line =~ m/^([-a-z0-9+]+):/) {
+					if ($line =~ m/^([-a-z0-9+.]+):/) {
 						$recommended_packages{$1} = 1;
 					}
 				}
@@ -128,7 +128,7 @@ on_pkgs_in_parallel {
 					if ($line =~ m/^local diversion |^diversion by/) {
 						next;
 					}
-					if ($line =~ m/^([-a-z0-9+]+):/) {
+					if ($line =~ m/^([-a-z0-9+.]+):/) {
 						$suggested_packages{$1} = 1;
 					}
 				}


### PR DESCRIPTION
According to Debian Policy §5.6.1 and 5.6.7, all other characters that are allowed in a Debian package name were already covered by the regex used here, but the dot was missing.

For example this fixes the ability to generate dependencies from ELF notes that point to libsndio.so.7 (libsndio7.0 package) or libpipewire-0.3.so.0 (libpipewire-0.3-0 package).

Closes: #1117245