### PR TITLE
test: do not fail if order of items changes

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -32,4 +32,4 @@ def test_requires():
 
     lines = generate_rpm([notes], 'Suggests', ('pcre2', 'tpm'))
     expect = expected[notes.elffile.elfclass]
-    assert lines == expect
+    assert sorted(lines) == sorted(expect)


### PR DESCRIPTION
Compiling notes.c with -O0:

```
Displaying notes found in: .note.dlopen
  Owner                Data size 	Description
  FDO                  0x00000088	FDO_DLOPEN_METADATA
    Dlopen Metadata: [{"feature":"fido2","description":"Support fido2 for encryption and authentication.","priority":"required","soname":["libfido2.so.1"]}]
  FDO                  0x00000084	FDO_DLOPEN_METADATA
    Dlopen Metadata: [{"feature":"pcre2","description":"Support pcre2 for regex","priority":"suggested","soname":["libpcre2-8.so.0","libpcre2-8.so.1"]}]
  FDO                  0x0000008e	FDO_DLOPEN_METADATA
    Dlopen Metadata: [{"feature":"lz4","description":"Support lz4 decompression in journal and coredump files","priority":"recommended","soname":["liblz4.so.1"]}]
  FDO                  0x00000095	FDO_DLOPEN_METADATA
    Dlopen Metadata: [{"feature":"tpm","priority":"recommended","soname":["libtss2-mu.so.0"]}, {"feature":"tpm","priority":"recommended","soname":["libtss2-esys.so.0"]}]
```

With -O2:

```
Displaying notes found in: .note.dlopen
  Owner                Data size 	Description
  FDO                  0x00000095	FDO_DLOPEN_METADATA
    Dlopen Metadata: [{"feature":"tpm","priority":"recommended","soname":["libtss2-mu.so.0"]}, {"feature":"tpm","priority":"recommended","soname":["libtss2-esys.so.0"]}]
  FDO                  0x0000008e	FDO_DLOPEN_METADATA
    Dlopen Metadata: [{"feature":"lz4","description":"Support lz4 decompression in journal and coredump files","priority":"recommended","soname":["liblz4.so.1"]}]
  FDO                  0x00000084	FDO_DLOPEN_METADATA
    Dlopen Metadata: [{"feature":"pcre2","description":"Support pcre2 for regex","priority":"suggested","soname":["libpcre2-8.so.0","libpcre2-8.so.1"]}]
  FDO                  0x00000088	FDO_DLOPEN_METADATA
    Dlopen Metadata: [{"feature":"fido2","description":"Support fido2 for encryption and authentication.","priority":"required","soname":["libfido2.so.1"]}]
```

So the test fails if -O2 is the default as the order is different

Follow-up for c2d3548b7edd863250027fd95e7c909fdd5d8ac4