### PR TITLE
rpm: use a '%{!r: ... }' guard around package notes LDFLAGS

### DIFF
--- a/rpm/redhat-package-notes.in
+++ b/rpm/redhat-package-notes.in
@@ -1,2 +1,2 @@
 *link:
-+ --package-metadata={\"type\":\"rpm\",\"name\":\"%:getenv(RPM_PACKAGE_NAME \",\"version\":\"%:getenv(RPM_PACKAGE_VERSION -%:getenv(RPM_PACKAGE_RELEASE \",\"architecture\":\"%:getenv(RPM_ARCH \",\"osCpe\":\"@OSCPE@\"}))))
++ %{!r:--package-metadata={\"type\":\"rpm\",\"name\":\"%:getenv(RPM_PACKAGE_NAME \",\"version\":\"%:getenv(RPM_PACKAGE_VERSION -%:getenv(RPM_PACKAGE_RELEASE \",\"architecture\":\"%:getenv(RPM_ARCH \",\"osCpe\":\"@OSCPE@\"}))))}


### PR DESCRIPTION
...to prevent double inclusion when performing a relocatable link ('-r'). Relates to https://bugzilla.redhat.com/show_bug.cgi?id=2362272.