### PR TITLE
Rework how rpm fileattr generation is configured

### DIFF
--- a/dlopen-notes.py
+++ b/dlopen-notes.py
@@ -154,15 +154,8 @@ def generate_rpm(elffiles, stanza, filter):
                 soname = next(iter(note['soname']))  # we take the first — most recommended — soname
                 yield f"{stanza}: {soname}{suffix}"
 
-def rpm_fileattr_generator(args):
-    if args.rpm_features is not None:
-        if not any(fnmatch.fnmatch(args.subpackage, pattern[0])
-                   for pattern in args.rpm_features):
-            # Current subpackage is not listed, nothing to do.
-            # Consume all input as required by the protocol.
-            sys.stdin.read()
-            return
 
+def rpm_fileattr_generator(args):
     for file in sys.stdin:
         file = file.strip()
         if not file:
@@ -174,23 +167,27 @@ def rpm_fileattr_generator(args):
         first = True
 
         for note in elffile.notes():
-            # Feature name is optional. Allow this to be matched
+            # Feature name is optional. Allow it to be matched
             # by the empty string ('') or a wildcard glob ('*').
             feature = note.get('feature', '')
+            level = None
 
-            if args.rpm_features is not None:
-                for package_pattern,feature_pattern in args.rpm_features:
-                    if (fnmatch.fnmatch(args.subpackage, package_pattern) and
-                        fnmatch.fnmatch(feature, feature_pattern)):
-                        break
-                else:
-                    # not matched
+            # Check if we got a feature level override
+            for package_pattern,feature_pattern,level_spec in args.rpm_features:
+                if not fnmatch.fnmatch(args.subpackage, package_pattern):
                     continue
-            else:
-                # if no mapping, print all features at the suggested level
-                level = Priority[note.get('priority', 'recommended')].rpm_name()
-                if level != args.rpm_fileattr:
-                    continue
+                if fnmatch.fnmatch(feature, feature_pattern):
+                    level = level_spec
+                    break
+
+            if level is None:
+                # if no mapping, check against the level suggested in the binary
+                level = note.get('priority', 'recommended')
+
+            fileattr = Priority[level].rpm_name()
+
+            if fileattr != args.rpm_fileattr:
+                continue
 
             if first:
                 print(f';{file}')
@@ -198,6 +195,27 @@ def rpm_fileattr_generator(args):
 
             soname = next(iter(note['soname']))  # we take the first — most recommended — soname
             print(f'{soname}{suffix}')
+
+
+@listify
+def parse_rpm_feature_spec(s):
+    """
+    The following format is expected:
+         subpackage:feature:level subpackage2:feature2:level
+         *:feature:level
+         # ignored comment
+         otherpackage:otherfeature:level
+         *:badfeature:ignored
+    """
+    for line in s.splitlines():
+        line = line.strip()
+        if line.startswith('#'):
+            continue
+        for word in line.split():
+            a, b, c = word.split(':', maxsplit=2)
+            if c not in {'required', 'recommended', 'suggested', 'ignored'}:
+                raise ValueError(f'Unexpected feature spec {word!r}')
+            yield (a, b, c)
 
 
 def make_parser():
@@ -257,10 +275,11 @@ def make_parser():
     )
     p.add_argument(
         '--rpm-features',
-        metavar='SUBPACKAGE:FEATURE,SUBPACKAGE:FEATURE',
-        type=lambda s: [x.split(':', maxsplit=1) for x in s.split(',')],
+        metavar='SUBPACKAGE:FEATURE:LEVEL…',
+        type=parse_rpm_feature_spec,
         action='extend',
-        help='Specify subpackage:feature mapping',
+        help='Override subpackage:feature:level mapping',
+        default=[],
     )
     p.add_argument(
         'filenames',

--- a/rpm/dlopen_notes.attr
+++ b/rpm/dlopen_notes.attr
@@ -3,20 +3,23 @@
 # This file is part of the package-notes package.
 #
 #
-# The spec file for a package can specify which features are listed
-# and at which level, using
-# '--rpm-features=SUBPACKAGE1:FEATURE1,SUBPACKAGE2:FEATURE2' option in
-# the '__dlopen_notes_TYPE_opts' macro, where TYPE is one of
-# 'requires', 'recommends', or 'suggests'. The macro should be declared
-# in the spec file using:
-#   %define __dlopen_notes_TYPE_opts SUBPACKAGE:FEATURE…
-# e.g.
-#   %define __dlopen_notes_recommends_opts *:zstd
+# This generator reads dlopen notes [1] from binaries in the buildroot and
+# creates Requires/Recommends/Suggests dependencies.
 #
-# The option accepts multiple comma-separated pairs, and can also be
-# specified multiple times. Both the subpackage name and feature name
-# can be a glob. If configuration is omitted, the priority recommended
-# in the notes is used.
+# The spec file can also override which features are listed and at which level
+# by setting %dlopen_notes_features. The macro contains zero or more lines,
+# each of which contains zero or more declarations, each in the form:
+#
+#    SUBPACKAGE:FEATURE:LEVEL
+#
+# SUBPACKAGE is the name of the subpackage where the override should apply.
+# FEATURE is the name of the feature specified in the notes. And LEVEL is the
+# dependency type, specified as one of the priority names 'required',
+# 'recommended', 'suggested', or 'ignored' in case the dependency for the
+# feature should be omitted. SUBPACKAGE and FEATURE can use shell-style
+# globs.
+#
+# [1] https://uapi-group.org/specifications/specs/elf_dlopen_metadata/
 #
 # The '--subpackage=SUBPACKAGE' option (inserted below) tells the generator
 # which subpackage is being processed.
@@ -26,19 +29,28 @@
 # libraries needed for the 'zstd' feature, all subpackages shall carry
 # 'Recommends' on all the libraries needed for the 'gzip' feature, and
 # the 'package' subpackage shall carry 'Suggests' for any feature
-# matching 'lzma' or 'bzip*'.
+# matching 'lzma' or 'bzip*':
 #
-#  %define __dlopen_notes_requires_opts   --rpm-features=package-libs:zstd
-#  %define __dlopen_notes_recommends_opts --rpm-features=*:gzip
-#  %define __dlopen_notes_suggests_opts   --rpm-features=package:lzma,package:bzip*
+#   %define dlopen_notes_features %{expand:
+#     package-libs:zstd:required
+#     *:gzip:recommended
+#     # This is a comment
+#     package:lzma:suggested
+#     package:bzip*:suggested
+#   }
+#
+# Additional parameters can be passed to the generator by setting
+# %__dlopen_notes_{requires,recommends,suggests}_opts.
 #
 # To opt out, undefine the %_dlopen_notes_generator macro:
-#  %undefine _dlopen_notes_generator
+#
+#   %undefine _dlopen_notes_generator
 
 %_dlopen_notes_generator   %{_bindir}/dlopen-notes
+%_dlopen_notes_generator_params %{!?_dlopen_notes_generator:true }%{_dlopen_notes_generator} --subpackage='%{name}' %{?dlopen_notes_features:--rpm-features='%dlopen_notes_features'}
 
-%__dlopen_notes_requires   %{!?_dlopen_notes_generator:true }%{_dlopen_notes_generator} --subpackage='%{name}' --rpm-fileattr=Requires
-%__dlopen_notes_recommends %{!?_dlopen_notes_generator:true }%{_dlopen_notes_generator} --subpackage='%{name}' --rpm-fileattr=Recommends
-%__dlopen_notes_suggests   %{!?_dlopen_notes_generator:true }%{_dlopen_notes_generator} --subpackage='%{name}' --rpm-fileattr=Suggests
+%__dlopen_notes_requires   %_dlopen_notes_generator_params --rpm-fileattr=Requires
+%__dlopen_notes_recommends %_dlopen_notes_generator_params --rpm-fileattr=Recommends
+%__dlopen_notes_suggests   %_dlopen_notes_generator_params --rpm-fileattr=Suggests
 %__dlopen_notes_protocol   multifile
 %__dlopen_notes_magic      ^.*ELF (32|64)-bit.*$


### PR DESCRIPTION
Previously, the --rpm-features setting had to either be absent, or list all the features that should be honoured. This was reasonable when we had just a handful of features and they were actually often declared on the wrong file. But after https://github.com/systemd/systemd/pull/42398, we want to do something more lightweight: just tweak the dependency level for some features, leaving most as declared in the upstream note. The existing configuration scheme did not allow this.

Also, listing the items in the spec file was exteremely cumbersome, because the param had to be structured as a very long comma-separated string.

Now, the --rpm-features param expects a series of lines, allows comments, and only needs to list the overrides, i.e. changes of dependency level.

Previously, we would specify config for "Requires", "Recommends", "Suggests" separately. This matches the rpm interface, which calls the generator again for each dependency level. But it turns out that configuring things like this is annoying, becuase if we override a feature to a different level in one of the configs, we'd still get the feature at the default level in one of the other sections. So to make this work without duplicates, the user would need to specify every feature twice, once to include, once to ignore. Now there's just one parameter and the deduplication is handled automatically by the machinery.

```spec
%define dlopen_notes_features=%{expand:
  # Upgrade dependency in main package
  systemd:mount:required

  # Upgrade dependency in subpackage
  systemd-udev:seccomp:required

  # Ignore an unwanted dependency
  *:qrencode:ignored
}
```